### PR TITLE
ci: add test and release workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,49 @@
+name: release
+permissions:
+  contents: write
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+jobs:
+  release:
+    name: Package and release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+      - run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+        name: Install dependencies
+      - name: Set version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Package
+        run: ./ci/build.sh
+        env:
+          SEMVER: ${{ env.RELEASE_VERSION }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          generate_release_notes: true
+          draft: true
+          files: |
+            ./dist/*
+
+      - name: Publish
+        if: startsWith(github.ref, 'refs/tags/') && env.PUBLISH_TOKEN
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          PUBLISH_REPO: ${{ secrets.PUBLISH_REPO }}
+          PUBLISH_OWNER: ${{ secrets.PUBLISH_OWNER }}
+        run: |
+          ./ci/publish.sh ./dist --repo "$PUBLISH_REPO" --owner "$PUBLISH_OWNER"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,120 @@
+name: Test
+
+on:
+  workflow_dispatch:
+  # Use a manual approval process before PR's are given access to
+  # the secrets which are required to run the integration tests.
+  # The PR code should be manually approved to see if it can be trusted.
+  # When in doubt, do not approve the test run.
+  # Reference: https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci
+  pull_request_target:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  merge_group:
+jobs:
+  approve:
+    name: Approve
+    environment:
+      # For security reasons, all pull requests need to be approved first before granting access to secrets
+      # So the environment should be set to have a reviewer/s inspect it before approving it
+      name: ${{ github.event_name == 'pull_request_target' && 'Test Pull Request' || 'Test Auto'  }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Wait for approval
+        run: echo "Approved"
+  test:
+    name: Test
+    needs: approve
+    environment:
+      name: Test Auto
+    runs-on: ubuntu-20.04
+    env:
+      COMPOSE_PROJECT_NAME: ci_${{github.run_id}}_${{github.run_attempt || '1'}}
+      DEVICE_ID: ci_${{github.run_id}}_${{github.run_attempt || '1'}}
+    steps:
+      # Checkout either the PR or the branch
+      - name: Checkout PR
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR. Only after the manual approval process
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        if: ${{ github.event_name != 'pull_request_target' }}
+
+      - uses: reubenmiller/setup-go-c8y-cli@main
+      - name: install c8y-tedge extension
+        run: c8y extension install thin-edge/c8y-tedge
+      - name: create .env file
+        run: |
+          touch .env
+          echo "DEVICE_ID=$DEVICE_ID" >> .env
+          echo 'C8Y_BASEURL="${{ secrets.C8Y_BASEURL }}"' >> .env
+          echo 'C8Y_USER="${{ secrets.C8Y_USER }}"' >> .env
+          echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
+          cat .env
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+      - run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+        name: Install dependencies
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+          cache-dependency-path: |
+            tests/requirements.txt
+
+      - uses: extractions/setup-just@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: |
+          just venv
+
+      - name: Start demo
+        run: |
+          just build
+          just up
+          just bootstrap
+
+      - name: Run tests
+        run: just test
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: reports
+          path: output
+
+      - name: Stop demo
+        if: always()
+        run: just down-all
+
+      - name: Cleanup Devices
+        if: always()
+        run: |
+          just cleanup "$DEVICE_ID"
+
+  generate_report:
+    name: Publish report
+    if: ${{ always() && github.event_name == 'pull_request_target' }}
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Download reports
+      uses: actions/download-artifact@v3
+      with:
+        name: reports
+        path: reports
+    - name: Send report to commit
+      uses: joonvena/robotframework-reporter-action@v2.2
+      with:
+        gh_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add workflows to test PRs and to publish a new release

Note: the settings used in the workflow can't be added until the repo is changed to public (due to restrictions in private repo features)