### PR TITLE
docs: add note about state of repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # tedge-rpm-plugin
 
+:construction: This repository is still under active development, so don't expect anything to work just yet.
+
 ## Plugin summary
 
-Manage rpm Linux packages on a device using thin-edge.io software management plugin api.
+Manage rpm packages on a device using thin-edge.io software management plugin api.
 
 **Technical summary**
 
@@ -13,7 +15,7 @@ The following details the technical aspects of the plugin to get an idea what sy
 |**Languages**|`shell` (posix compatible)|
 |**CPU Architectures**|`all/noarch`. Not CPU specific|
 |**Supported init systems**|`N/A`|
-|**Required Dependencies**|-|
+|**Required Dependencies**|`dnf`|
 |**Optional Dependencies (feature specific)**|-|
 
 ### How to do I get it?
@@ -22,31 +24,43 @@ The following linux package formats are provided on the releases page and also i
 
 |Operating System|Repository link|
 |--|--|
-|redhat Linux (rpm)|[![Latest version of 'tedge-rpm-plugin' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/thinedge/community/rpm/tedge-rpm-plugin/latest/a=noarch;d=rpm%252Fany-version/?render=true&show_latest=true)](https://cloudsmith.io/~thinedge/repos/community/packages/detail/rpm/tedge-rpm-plugin/latest/a=noarch;d=rpm%252Fany-version/)|
+|RHEL/CentOS/Fedora|[![Latest version of 'tedge-rpm-plugin' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/thinedge/community/rpm/tedge-rpm-plugin/latest/a=noarch;d=rpm%252Fany-version/?render=true&show_latest=true)](https://cloudsmith.io/~thinedge/repos/community/packages/detail/rpm/tedge-rpm-plugin/latest/a=noarch;d=rpm%252Fany-version/)|
 
 ### What will be deployed to the device?
 
 * The following software management plugins which is called when installing and removing `rpm` packages via Cumulocity IoT
-    * `dnf` - Manage (list/install/remove) packages via the RHEL Linux Package Manager
+    * `rpm` - Manage (list/install/remove) packages via the dnf Package Manager
 
 
 ## Plugin Dependencies
 
 The following packages are required to use the plugin:
 
-* RHEL Linux
+* dnf
 
 ## Development
 
+The following tools are requires for local development. Please install them before following the instructions:
+
+* [nfpm](https://nfpm.goreleaser.com/tips/) - Tool to build linux packages
+* [go-c8y-cli](https://goc8ycli.netlify.app/) - A Cumulocity IoT CLI app
+* [c8y-tedge extension](https://github.com/thin-edge/c8y-tedge) - go-c8y-cli extension for thin-edge.io to help with bootstrapping
+
 ### Start demo
 
-1. Start the demo
+1. Build the tedge-rpm-plugin package
+
+    ```
+    just build
+    ```
+
+2. Start the demo
 
     ```sh
     just up
     ```
 
-2. Bootstrap the device
+3. Bootstrap the device
 
     ```sh
     just bootstrap


### PR DESCRIPTION
Add warning to README to communicate that the repo is still being developed as the repo will be made public soon (to enable proper workflows).