### PR TITLE
Fix microdnf handling

### DIFF
--- a/images/rockylinux.dockerfile
+++ b/images/rockylinux.dockerfile
@@ -1,7 +1,7 @@
 FROM rockylinux:9-minimal
 
 ENV container docker
-RUN microdnf -y install sudo
+RUN microdnf -y install sudo ca-certificates
 # see https://hub.docker.com/_/rockylinux
 # RockyLinux:9 missing /usr/sbin/init -> ../lib/systemd/systemd
 #  see https://github.com/rocky-linux/sig-cloud-instance-images/issues/39
@@ -18,6 +18,9 @@ RUN ([ -d /lib/systemd/system/sysinit.target.wants ] && cd /lib/systemd/system/s
 
 # install thin-edge.io
 RUN curl -fsSL https://thin-edge.io/install.sh | sh -s
+
+# rockylinux minimal uses a single cert.pem file instead of the ssl directory
+RUN tedge config set c8y.root_cert_path /etc/ssl/cert.pem
 
 # install sm-plugin (microdnf does not support installing from file)
 COPY ./dist/*.rpm /tmp/

--- a/src/sm-plugin/tedge-rpm-plugin
+++ b/src/sm-plugin/tedge-rpm-plugin
@@ -96,7 +96,7 @@ case "$COMMAND" in
                 dnf check-update ||:
                 ;;
             microdnf)
-                microdnf check-update ||:
+                # microdnf does not implement check-update
                 ;;
         esac
         ;;
@@ -124,8 +124,27 @@ case "$COMMAND" in
             log "Installing from file: $FILE"
             # dnf requires the file to have an .rpm extension
             ln -sf "$FILE" "$FILE.rpm"
-            $PACKAGE_MANAGER install -y "$FILE.rpm" || exit "$EXIT_FAILURE"
+
+            CODE=
+            case "$PACKAGE_MANAGER" in
+                microdnf)
+                    # microdnf does not support installing from local files, so use rpm directly
+                    if ! rpm -i "$FILE.rpm"; then
+                        CODE="$EXIT_FAILURE"
+                    fi
+                    ;;
+                *)
+                    if ! $PACKAGE_MANAGER install -y "$FILE.rpm"; then
+                        CODE="$EXIT_FAILURE"
+                    fi
+                    ;;
+            esac
+
             rm -f "$FILE.rpm"
+
+            if [ -n "$CODE" ]; then
+                exit "$CODE"
+            fi
         else
             MODULE="$MODULE_NAME"
             if [ -n "$MODULE_VERSION" ] && [ "$MODULE_VERSION" != "latest" ]; then


### PR DESCRIPTION
Fix rockylinux minimal (microdnf) tests and sm-plugin handling:
* Use custom c8y root cert path as rockylinux minimal uses a different ssl cert setup
* Fix handling of local rpm file installation (as microdnf does not support it)