### PR TITLE
ci: fix cloudsmith target distribution when publishing

### DIFF
--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -124,4 +124,4 @@ publish() {
     done
 }
 
-publish "$SOURCE_PATH" "*.rpm" rpm "rpm" "any-version"
+publish "$SOURCE_PATH" "*.rpm" rpm "any-distro" "any-version"


### PR DESCRIPTION
Fix wrong distribution target selected to publish the rpm package to in cloudsmith.