### PR TITLE
test: refactor tests to use per-test device setup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,6 @@ on:
   # Reference: https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci
   pull_request_target:
     branches: [ main ]
-  push:
-    branches: [ main ]
   merge_group:
 
 permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,9 +38,6 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
-    env:
-      COMPOSE_PROJECT_NAME: ci_${{ matrix.job.image }}_${{github.run_id}}_${{github.run_attempt || '1'}}
-      DEVICE_ID: ci_${{ matrix.job.image }}_${{github.run_id}}_${{github.run_attempt || '1'}}
     
     strategy:
       fail-fast: false
@@ -57,13 +54,9 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
 
-      - uses: reubenmiller/setup-go-c8y-cli@main
-      - name: install c8y-tedge extension
-        run: c8y extension install thin-edge/c8y-tedge
       - name: create .env file
         run: |
           touch .env
-          echo "DEVICE_ID=$DEVICE_ID" >> .env
           echo 'C8Y_BASEURL="${{ secrets.C8Y_BASEURL }}"' >> .env
           echo 'C8Y_USER="${{ secrets.C8Y_USER }}"' >> .env
           echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
@@ -91,31 +84,17 @@ jobs:
         run: |
           just venv
 
-      - name: Start demo
-        run: |
-          just build
-          just up
-          just bootstrap
-
       - name: Run tests
-        run: just test
+        run: |
+          just test
 
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: reports-${{matrix.job.target}}
+          name: reports-${{matrix.job.image}}
           path: output
 
-      - name: Stop demo
-        if: always()
-        run: just down-all
-
-      - name: Cleanup Devices
-        if: always()
-        run: |
-          just cleanup "$DEVICE_ID"
-      
       - name: Send report to commit
         uses: joonvena/robotframework-reporter-action@v2.5
         if: ${{ always() && github.event_name == 'pull_request_target' }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python3",
-    "robot.language-server.python": "${workspaceFolder}/.venv/bin/python3",
-    "robot.python.executable": "${workspaceFolder}/.venv/bin/python3",
-    "python.envFile": "${workspaceFolder}/.env"
+    "python.envFile": "${workspaceFolder}/.env",
+    "python.terminal.useEnvFile": true,
+    "robotcode.debug.attachPython": true
 }

--- a/README.md
+++ b/README.md
@@ -42,41 +42,30 @@ The following packages are required to use the plugin:
 The following tools are requires for local development. Please install them before following the instructions:
 
 * [nfpm](https://nfpm.goreleaser.com/tips/) - Tool to build linux packages
-* [go-c8y-cli](https://goc8ycli.netlify.app/) - A Cumulocity IoT CLI app
-* [c8y-tedge extension](https://github.com/thin-edge/c8y-tedge) - go-c8y-cli extension for thin-edge.io to help with bootstrapping
 
-### Start demo
+### Testing
 
-1. Build the tedge-rpm-plugin package
+1. Create a dotenv (`.env`) file containing the Cumulocity credentials to be used for the system tests
 
-    ```sh
-    just build
-    ```
-
-2. Start the demo
+    **file: .env**
 
     ```sh
-    just up
+    C8Y_BASEURL=https://example.cumulocity.com
+    C8Y_USER=
+    C8Y_PASSWORD=
+
+    # one of; IMAGE=rockylinux|opensuse|fedora
+    IMAGE=fedora
     ```
 
-3. Activate your Cumulocity IoT session in go-c8y-cli where you want to bootstrap the device to
+2. Install the test dependencies
 
     ```sh
-    set-session
+    just venv
     ```
 
-    `set-session` is part of [go-c8y-cli](https://goc8ycli.netlify.app/), check out the documentation for instructions on how to install and create your session if you don't already have one.
-
-4. Bootstrap the device
+3. Run test tests
 
     ```sh
-    just bootstrap
+    just test
     ```
-
-    The bootstrap command used the [c8y-tedge extension](https://github.com/thin-edge/c8y-tedge).
-
-### Stop demo
-
-```sh
-just down
-```

--- a/justfile
+++ b/justfile
@@ -1,32 +1,12 @@
 set dotenv-load
 
-# Start the demo
-up *args="":
-    docker compose up --detach --build {{args}}
-
-# Stop the demo
-down *args="":
-    docker compose down {{args}}
-
-# Stop the demo and destroy the data
-down-all:
-    docker compose down -v
-
-# Configure and register the device to the cloud (requires go-c8y-cli and c8y-tedge extension)
-bootstrap *args="":
-    c8y tedge bootstrap-container tedge "$DEVICE_ID" {{args}}
-
-# Start a shell
-shell *args='sh':
-    docker compose exec tedge {{args}}
-
 # Install python virtual environment
 venv:
   [ -d .venv ] || python3 -m venv .venv
   ./.venv/bin/pip3 install -r tests/requirements.txt
 
 # Run tests
-test *args='':
+test *args='': (build)
   ./.venv/bin/python3 -m robot.run --outputdir output {{args}} tests
 
 # Build linux package
@@ -36,10 +16,3 @@ build:
 # Build packages used in tests
 build-test-packages:
     nfpm package -f tests/testdata/nfpm-example.yaml -p rpm --target tests/testdata
-
-# Cleanup device and all it's dependencies
-cleanup DEVICE_ID $CI="true":
-    echo "Removing device and child devices (including certificates)"
-    c8y devicemanagement certificates list -n --tenant "$(c8y currenttenant get --select name --output csv)" --filter "name eq {{DEVICE_ID}}" --pageSize 2000 | c8y devicemanagement certificates delete --tenant "$(c8y currenttenant get --select name --output csv)"
-    c8y inventory find -n --owner "device_{{DEVICE_ID}}" -p 100 | c8y inventory delete
-    c8y users delete -n --id "device_{{DEVICE_ID}}" --tenant "$(c8y currenttenant get --select name --output csv)" --silentStatusCodes 404 --silentExit

--- a/tests/main/management.robot
+++ b/tests/main/management.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    ../resources/common.robot
-Library    Cumulocity
 
-Suite Setup    Set Main Device
+Test Setup       Setup Device
+Test Teardown    Collect Logs
 
 *** Test Cases ***
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 robotframework~=7.0.0
 robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.51.1
+robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.26.0

--- a/tests/resources/common.robot
+++ b/tests/resources/common.robot
@@ -1,14 +1,37 @@
 *** Settings ***
 Library    Cumulocity
+Library    DeviceLibrary
 
 *** Variables ***
-
-${DEVICE_ID}         %{DEVICE_ID=main}
 
 # Cumulocity settings
 &{C8Y_CONFIG}        host=%{C8Y_BASEURL= }    username=%{C8Y_USER= }    password=%{C8Y_PASSWORD= }    tenant=%{C8Y_TENANT= }
 
 *** Keywords ***
 
-Set Main Device
-    Cumulocity.Set Device    ${DEVICE_ID}
+Setup Device
+    ${DEVICE_ID}=    DeviceLibrary.Setup    compose_file=${CURDIR}/../../docker-compose.yaml    skip_bootstrap=${True}
+    Set Test Variable    $DEVICE_ID
+    Bootstrap Device    ${DEVICE_ID}
+
+Bootstrap Device
+    [Arguments]    ${device_id}
+    ${domain}=    Cumulocity.Get Domain
+    DeviceLibrary.Execute Command    cmd=tedge config set c8y.url ${domain}
+    ${credentials}=    Cumulocity.Bulk Register Device With Cumulocity CA    external_id=${device_id}
+    DeviceLibrary.Execute Command    cmd=tedge cert download c8y --device-id ${device_id} --retry-every 5s --one-time-password "${credentials.one_time_password}"
+    DeviceLibrary.Execute Command    cmd=tedge reconnect c8y
+    Cumulocity.External Identity Should Exist    external_id=${device_id}
+    ${operation}=    Cumulocity.Get Configuration    typename=tedge-configuration-plugin    timeout=60
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Sleep    2s
+
+Collect Logs
+    Run Keyword And Continue On Failure    Get Workflow Logs
+    Run Keyword And Continue On Failure    Get Service Logs
+
+Get Workflow Logs
+    DeviceLibrary.Execute Command    head -n-0 /var/log/tedge/agent/*
+
+Get Service Logs
+    DeviceLibrary.Execute Command    journalctl -n 1000 --no-pager -u "tedge-*"


### PR DESCRIPTION
Refactor the system tests by using the robotframework-devicelibrary to start a test container (using docker-compose).

* automatic creation of test containers during the test (including cleanup)
* collect logs on teardown